### PR TITLE
chore: Remove unused vct discovery domains parameter

### DIFF
--- a/readthedocs/source/orb/logmonitoring.md
+++ b/readthedocs/source/orb/logmonitoring.md
@@ -14,7 +14,7 @@ If the service has already encountered this log and log's STH has changed since 
 - Fetch a consistency proof for the new STH with the previous STH.
 - Verify the consistency proof.
 
-Upon successfull STH signature and consistency verificiation, log monitoring service will 
+Upon successful STH signature and consistency verification, log monitoring service will 
 save current STH for each domain.
 
 The service can be configured to retrieve and store all log entries during log monitoring. See [Log Entries Store Enabled Parameter](parameters.html###vct-log-entries-store-enabled).

--- a/readthedocs/source/orb/parameters.md
+++ b/readthedocs/source/orb/parameters.md
@@ -519,14 +519,6 @@ Always sign with local witness flag (default true).
 
 Discovery domains.
 
-### discovery-vct-domains
-
-| Arg                     | Env                    | Default |
-|-------------------------|------------------------|---------|
-| --discovery-vct-domains | DISCOVERY_VCT_DOMAINS  |         |
-
-Discovery VCT domains.
-
 ### discovery-minimum-resolvers
 
 | Arg                           | Env                          | Default |


### PR DESCRIPTION
Remove unused vct discovery domain parameter

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>